### PR TITLE
Update installation snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Installation
 
 ```
-go get -u github.com/Gonzih/log-replay
+go install github.com/Gonzih/log-replay@latest
 ```
 
 ## Usage


### PR DESCRIPTION
`go get` is deprecated for installation:
https://go.dev/doc/go-get-install-deprecation

and does not work in recent golang version.